### PR TITLE
navbar menu modified and social links not overlapping

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -148,7 +148,7 @@ section {
 
 .home .social {
   z-index: 888;
-  position: fixed;
+  position: absolute;
   right: 30px;
   top: 50%;
   transform: translateY(-50%);

--- a/index.html
+++ b/index.html
@@ -51,8 +51,8 @@
       <div class="menu-btn"></div>
       <div class="mid">
         <div class="navbar">
-          <a href="#">Home</a>
-          <a href="#">Services</a>
+          <a href="#homepage">Home</a>
+          <a href="#places">Trips</a>
           <a href="blog.html">Blogs</a>
           <a href="#about">About Us</a>
           <a href="contact.html">Contact</a>
@@ -60,7 +60,7 @@
       </div>
     </header>
 
-    <section class="home">
+    <section class="home" id="homepage">
       <video class="bg-video" src="vid/bg1.mp4" autoplay muted loop></video>
       <div class="content">
         <h1>
@@ -96,7 +96,7 @@
     </section>
 
     <!--==============Places===================-->
-    <div class="places">
+    <div class="places" id="places">
       <div class="places-text">
         <h2>Most Loved Places</h2>
       </div>


### PR DESCRIPTION
navbar menu modified(Services->Trips with proper link) and social links at home page is no more overlapping.

#menu after:- 
![menu_modified-after](https://github.com/user-attachments/assets/cadd3215-d269-45b1-aa85-b330bf35f3e4)

#issue_before
![social-links_before](https://github.com/user-attachments/assets/9edecdbb-e139-4bac-9688-120af51bf6fb)

#issue_after
![social-links_after](https://github.com/user-attachments/assets/7f488fa3-ca68-4b38-acea-09abe3560f15)
